### PR TITLE
Fix encoding issues with certain characters

### DIFF
--- a/dev-vault/main.go
+++ b/dev-vault/main.go
@@ -267,6 +267,7 @@ var (
 	DATA = map[string]interface{}{
 		"username":   "psy",
 		"password":   "hunter2",
+		"html":       "<html><body><h1>encodingisevil&wrong</h1></body></html>",
 		"oopa":       "gangnam",
 		"roles":      []string{"reader", "writer", "philantropist"},
 		"a":          "bcd, etc",

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -137,11 +138,14 @@ func main() {
 				return
 			case tcell.KeyEnter:
 				if !(reflect.ValueOf(ui.Secret).IsZero()) {
-					bytes, err := json.MarshalIndent(ui.Secret, "", "  ")
-					if err != nil {
+					var buf bytes.Buffer
+					encoder := json.NewEncoder(&buf)
+					encoder.SetEscapeHTML(false)
+					encoder.SetIndent("", "  ")
+					if err := encoder.Encode(ui.Secret); err != nil {
 						panic(fmt.Sprintf("Failed to marshal secret: %s", err))
 					}
-					ui.Result = bytes
+					ui.Result = buf.Bytes()
 				}
 				return
 			case tcell.KeyCtrlO:


### PR DESCRIPTION
Golang's default is apparently to output web-safe JSON. This means the output you get from Pole will web-encode data.

I'm not sure if Pole is supposed to support binary data in the JSON output. If so, then this patch is probably a bad idea.